### PR TITLE
golangci-lintを実行するCIパイプラインを構築

### DIFF
--- a/.github/workflows/golangci-lint-with-reviewdog.yaml
+++ b/.github/workflows/golangci-lint-with-reviewdog.yaml
@@ -1,0 +1,30 @@
+name: Lint Source Code with golangci-lint-with-reviewdog
+
+on:
+  pull_request:
+    branches: 
+      # mainブランチへのPR時にワークフローを実行する
+      - main
+
+jobs:
+  golangci-lint-with-reviewdog:
+    strategy:
+      fail-fast: false
+      matrix:
+        go: [1.17, 1.18, 1.19]
+        os: [macos-latest, windows-latest, ubuntu-latest]
+
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v3
+        
+      - name: golangci-lint
+        uses: reviewdog/action-golangci-lint@v2
+        with:
+          cache: false
+          github_token: ${{ github.token }}
+          go_version: ${{ matrix.go }}
+          golangci_lint_flags: "--enable-all --exclude-use-default=false"
+          golangci_lint_version: v1.48.0


### PR DESCRIPTION
golangci-lintの実行タイミングは2つ
1. mainブランチ以外のブランチへのPush
2. mainブランチへのPull Request
